### PR TITLE
Adding native advance ads integration

### DIFF
--- a/app/src/debug/res/values/const.xml
+++ b/app/src/debug/res/values/const.xml
@@ -3,6 +3,7 @@
     <!--Admob config-->
     <string name="admob_app_id">ca-app-pub-3202373510164662~8879669592</string>
     <!-- https://developers.google.com/admob/android/test-ads -->
-    <string name="dashboard_banner_ad_id">ca-app-pub-3940256099942544/6300978111</string>
+    <string name="settings_banner_ad_id">ca-app-pub-3940256099942544/6300978111</string>
+    <string name="dashboard_native_ad_id">ca-app-pub-3940256099942544/2247696110</string>
     <string name="detail_interstitial_ad_id">ca-app-pub-3940256099942544/1033173712</string>
 </resources>

--- a/app/src/main/java/com/kevalpatel2106/yip/dashboard/adapter/ProgressViewHolder.kt
+++ b/app/src/main/java/com/kevalpatel2106/yip/dashboard/adapter/ProgressViewHolder.kt
@@ -4,14 +4,24 @@ import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.RatingBar
+import android.widget.TextView
+import com.google.android.gms.ads.AdLoader
 import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.formats.NativeAdOptions
+import com.google.android.gms.ads.formats.UnifiedNativeAd
+import com.google.android.gms.ads.formats.UnifiedNativeAdView
 import com.kevalpatel2106.yip.R
 import com.kevalpatel2106.yip.core.setProgressTint
+import com.kevalpatel2106.yip.core.showOrHide
 import com.kevalpatel2106.yip.entity.Progress
 import com.kevalpatel2106.yip.recyclerview.viewholders.YipViewHolder
 import kotlinx.android.synthetic.main.row_list_ads.view.*
 import kotlinx.android.synthetic.main.row_progress.*
 import java.util.*
+
 
 internal class ProgressViewHolder(itemView: View) : YipViewHolder(itemView) {
 
@@ -43,10 +53,61 @@ internal class AdsViewHolder(itemView: View) : YipViewHolder(itemView) {
     override fun isDragSupported(): Boolean = false
 
     companion object {
+
         fun create(parent: ViewGroup): AdsViewHolder {
             val view = LayoutInflater.from(parent.context).inflate(R.layout.row_list_ads, parent, false)
-            view.list_ads_view.loadAd(AdRequest.Builder().build())  // Initialize ads.
+
+            // Set up native ad view
+            val adView = (view.findViewById(R.id.ad_view) as UnifiedNativeAdView).apply {
+                mediaView = ad_media
+                headlineView = ad_headline
+                bodyView = ad_body
+                callToActionView = ad_call_to_action
+                iconView = ad_icon
+                priceView = ad_price
+                starRatingView = ad_stars
+                storeView = ad_store
+                advertiserView = ad_advertiser
+            }
+
+            AdLoader.Builder(parent.context, "ca-app-pub-3940256099942544/2247696110")
+                    .forUnifiedNativeAd { bind(it, adView) }
+                    .withNativeAdOptions(NativeAdOptions.Builder().build())
+                    .build()
+                    .loadAd(AdRequest.Builder().build())
+
             return AdsViewHolder(view)
+        }
+
+        private fun bind(nativeAd: UnifiedNativeAd, adView: UnifiedNativeAdView) {
+            // Some assets are guaranteed to be in every UnifiedNativeAd.
+            (adView.headlineView as TextView).text = nativeAd.headline
+            (adView.bodyView as TextView).text = nativeAd.body
+
+            adView.callToActionView.showOrHide(nativeAd.callToAction != null)
+            (adView.callToActionView as Button).text = nativeAd.callToAction
+
+            // These assets aren't guaranteed to be in every UnifiedNativeAd, so it's important to
+            // check before trying to display them.
+            val icon = nativeAd.icon
+            adView.iconView.showOrHide(icon != null)
+            if (icon != null) {
+                (adView.iconView as ImageView).setImageDrawable(icon.drawable)
+            }
+
+            adView.priceView.showOrHide(nativeAd.price != null)
+            (adView.priceView as TextView).text = nativeAd.price
+
+            adView.storeView.showOrHide(nativeAd.store != null)
+            (adView.storeView as TextView).text = nativeAd.store
+
+            adView.starRatingView.showOrHide(nativeAd.starRating != null)
+            (adView.starRatingView as RatingBar).rating = nativeAd.starRating?.toFloat() ?: 0f
+
+            adView.advertiserView.showOrHide(nativeAd.advertiser != null)
+            (adView.advertiserView as TextView).text = nativeAd.advertiser
+
+            adView.setNativeAd(nativeAd)
         }
     }
 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -39,7 +39,7 @@
         android:layout_gravity="center"
         android:gravity="center"
         app:adSize="SMART_BANNER"
-        app:adUnitId="@string/dashboard_banner_ad_id"
+        app:adUnitId="@string/settings_banner_ad_id"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/row_list_ads.xml
+++ b/app/src/main/res/layout/row_list_ads.xml
@@ -1,20 +1,142 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/spacing_anti"
+    android:layout_height="wrap_content"
     app:cardBackgroundColor="@color/window_background_color_bright"
     app:cardCornerRadius="0dp"
-    app:cardElevation="@dimen/spacing_pico"
-    app:contentPadding="@dimen/spacing_nano">
+    app:cardElevation="@dimen/spacing_pico">
 
-    <com.google.android.gms.ads.AdView xmlns:ads="http://schemas.android.com/apk/res-auto"
-        android:id="@+id/list_ads_view"
+    <com.google.android.gms.ads.formats.UnifiedNativeAdView
+        android:id="@+id/ad_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center"
-        android:gravity="center"
-        ads:adSize="SMART_BANNER"
-        ads:adUnitId="@string/dashboard_banner_ad_id" />
+        android:layout_height="wrap_content">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_pico">
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/ad_attribution"
+                style="@style/NanoText.White"
+                android:layout_width="@dimen/spacing_small"
+                android:layout_height="@dimen/spacing_small"
+                android:background="#FFCC66"
+                android:text="@string/ad_identifier"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/ad_icon"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginStart="@dimen/spacing_nano"
+                android:layout_marginTop="@dimen/spacing_nano"
+                android:scaleType="fitXY"
+                app:layout_constraintStart_toEndOf="@+id/ad_attribution"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:src="@tools:sample/avatars" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/ad_headline"
+                style="@style/MediumText.Accent"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/spacing_nano"
+                android:layout_marginStart="@dimen/spacing_nano"
+                android:textColor="@android:color/holo_blue_dark"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toStartOf="@+id/ad_call_to_action"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toEndOf="@id/ad_icon"
+                app:layout_constraintTop_toTopOf="@+id/ad_icon"
+                tools:text="@tools:sample/lorem" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/ad_advertiser"
+                style="@style/SmallText.Secondary"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginTop="@dimen/spacing_pico"
+                android:textStyle="bold"
+                app:layout_constraintStart_toStartOf="@+id/ad_headline"
+                app:layout_constraintTop_toBottomOf="@+id/ad_headline"
+                tools:text="@tools:sample/lorem" />
+
+            <RatingBar
+                android:id="@+id/ad_stars"
+                style="?android:attr/ratingBarStyleSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/spacing_nano"
+                android:layout_marginStart="@dimen/spacing_micro"
+                android:isIndicator="true"
+                android:numStars="5"
+                android:stepSize="0.5"
+                app:layout_constraintBottom_toBottomOf="@+id/ad_advertiser"
+                app:layout_constraintEnd_toStartOf="@+id/ad_call_to_action"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toEndOf="@id/ad_advertiser"
+                app:layout_constraintTop_toTopOf="@+id/ad_advertiser"
+                tools:rating="3.5" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/ad_body"
+                style="@style/SmallText.Secondary"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/spacing_nano"
+                android:layout_marginStart="@dimen/spacing_nano"
+                android:layout_marginTop="@dimen/spacing_micro"
+                app:layout_constraintEnd_toStartOf="@+id/ad_price"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ad_advertiser"
+                tools:text="@tools:sample/lorem" />
+
+            <com.google.android.gms.ads.formats.MediaView
+                android:id="@+id/ad_media"
+                android:layout_width="match_parent"
+                android:layout_height="175dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="@dimen/spacing_micro"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ad_body" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/ad_price"
+                style="@style/NanoText.Secondary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/spacing_nano"
+                app:layout_constraintBottom_toBottomOf="@+id/ad_store"
+                app:layout_constraintEnd_toStartOf="@id/ad_store"
+                app:layout_constraintTop_toTopOf="@+id/ad_store"
+                tools:text="£30.00" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/ad_store"
+                style="@style/NanoText.Secondary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ad_call_to_action"
+                tools:text="Play Store" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/ad_call_to_action"
+                android:layout_width="wrap_content"
+                android:layout_height="42dp"
+                android:layout_marginEnd="@dimen/spacing_small"
+                android:visibility="invisible"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="@android:string/ok" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.gms.ads.formats.UnifiedNativeAdView>
 </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/values/const.xml
+++ b/app/src/main/res/values/const.xml
@@ -9,5 +9,6 @@
     <string name="pref_key_privacy_policy" translatable="false">pref_key_privacy_policy</string>
     <string name="pref_key_pro_version_header" translatable="false">pro_version_header</string>
     <string name="pref_key_open_source_licences" translatable="false">pref_key_open_source_licences</string>
+    <string name="ad_identifier">Ad</string>
     <!--TODO: Categorize the constants-->
 </resources>

--- a/app/src/release/res/values/const.xml
+++ b/app/src/release/res/values/const.xml
@@ -2,6 +2,7 @@
 <resources>
     <!--Admob config-->
     <string name="admob_app_id">ca-app-pub-3202373510164662~8879669592</string>
-    <string name="dashboard_banner_ad_id">ca-app-pub-3202373510164662/2449992610</string>
+    <string name="settings_banner_ad_id">ca-app-pub-3202373510164662/2449992610</string>
+    <string name="dashboard_native_ad_id">ca-app-pub-3940256099942544/2247696110</string> <!--TODO-->
     <string name="detail_interstitial_ad_id">ca-app-pub-3202373510164662/1149697234</string>
 </resources>


### PR DESCRIPTION
This PR ad the [native advance ads](https://developers.google.com/admob/android/native/start) from the AdMob to the dashboard.

- Native Ads Advanced is currently released to a limited set of publishers. This PR uses the [test ad unit](https://developers.google.com/admob/android/native/start#always_test_with_test_ads) id to get the native ads working in the dashboard.

Once native ads roll out for everyone, we can create native ads on AdMob dashboard as explained here  👉 https://support.google.com/admob/answer/7187428.

**Let's wait for it to get released officially.** 

#### Here is how it looks:

<img src="https://user-images.githubusercontent.com/20060162/53288435-c7902e00-377f-11e9-9f4c-fe7ea807521a.png" width=350/>
